### PR TITLE
[AL-1418] Fix for lesson pages throwing a 500 error

### DIFF
--- a/curricula/__init__.py
+++ b/curricula/__init__.py
@@ -4,7 +4,7 @@ django-lessons
 __version_info__ = {
     'major': 3,
     'minor': 0,
-    'micro': 0,
+    'micro': 1,
     'releaselevel': 'final',
     'serial': 1,
 }

--- a/curricula/utils.py
+++ b/curricula/utils.py
@@ -195,7 +195,7 @@ def activities_info(ids, l_id=None):
         learning_objs |= set([objrel.objective for objrel in objectives_list])
         resources |= set(activity.resources.all().values_list('object_type_id', 'object_id'))
 
-        if activity.internet_access_type > inet_access:
+        if activity.internet_access_type and activity.internet_access_type > inet_access:
             inet_access = activity.internet_access_type
         plugins |= set(activity.plugin_types.values_list('id', flat=True))
         tech |= set(activity.tech_setup_types.values_list('id', flat=True))


### PR DESCRIPTION
Issues:
------
- [AL-1418: Lesson pages oopsing](https://nationalgeographicatlassianprod.atlassian.net/browse/AL-1418)

Description
-------
fix for: `Error:TypeError at /lesson/making-decision-about-construction-oil-pipeline-th/'>' not supported between instances of 'NoneType' and 'int'`
